### PR TITLE
rename cmake option to BUILD_TESTING

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -416,13 +416,9 @@ add_subdirectory(Eigen)
 
 add_subdirectory(doc EXCLUDE_FROM_ALL)
 
-include(EigenConfigureTesting)
-
-option(EIGEN_ENABLE_TESTS "Enable creation of Eigen tests." ON)
-if(EIGEN_ENABLE_TESTS)
-  # fixme, not sure this line is still needed:
-  enable_testing() # must be called from the root CMakeLists, see man page
-
+option(BUILD_TESTING "Enable creation of Eigen tests." ON)
+if(BUILD_TESTING)
+  include(EigenConfigureTesting)
 
   if(EIGEN_LEAVE_TEST_IN_ALL_TARGET)
     add_subdirectory(test) # can't do EXCLUDE_FROM_ALL here, breaks CTest
@@ -464,7 +460,9 @@ endif(NOT WIN32)
 
 configure_file(scripts/cdashtesting.cmake.in cdashtesting.cmake @ONLY)
 
-ei_testing_print_summary()
+if(BUILD_TESTING)
+  ei_testing_print_summary()
+endif()
 
 message(STATUS "")
 message(STATUS "Configured Eigen ${EIGEN_VERSION_NUMBER}")

--- a/blas/CMakeLists.txt
+++ b/blas/CMakeLists.txt
@@ -45,10 +45,12 @@ install(TARGETS eigen_blas eigen_blas_static
 
 if(EIGEN_Fortran_COMPILER_WORKS)
 
-if(EIGEN_LEAVE_TEST_IN_ALL_TARGET)
-  add_subdirectory(testing) # can't do EXCLUDE_FROM_ALL here, breaks CTest
-else()
-  add_subdirectory(testing EXCLUDE_FROM_ALL)
+if(BUILD_TESTING)
+  if(EIGEN_LEAVE_TEST_IN_ALL_TARGET)
+    add_subdirectory(testing) # can't do EXCLUDE_FROM_ALL here, breaks CTest
+  else()
+    add_subdirectory(testing EXCLUDE_FROM_ALL)
+  endif()
 endif()
 
 endif()

--- a/unsupported/CMakeLists.txt
+++ b/unsupported/CMakeLists.txt
@@ -1,7 +1,9 @@
 add_subdirectory(Eigen)
 add_subdirectory(doc EXCLUDE_FROM_ALL)
-if(EIGEN_LEAVE_TEST_IN_ALL_TARGET)
-  add_subdirectory(test) # can't do EXCLUDE_FROM_ALL here, breaks CTest
-else()
-  add_subdirectory(test EXCLUDE_FROM_ALL)
+if(BUILD_TESTING)
+  if(EIGEN_LEAVE_TEST_IN_ALL_TARGET)
+    add_subdirectory(test) # can't do EXCLUDE_FROM_ALL here, breaks CTest
+  else()
+    add_subdirectory(test EXCLUDE_FROM_ALL)
+  endif()
 endif()


### PR DESCRIPTION
- rename variable EIGEN_BUILD_TESTS to BUILD_TESTING to be more cmake
  conform

this is the latest status of the [upstream pull request](https://bitbucket.org/eigen/eigen/pull-requests/287).

@ruslo Can you tag a new release and I'll update the Eigen-hunter package